### PR TITLE
#first and #last are returning destroyed objects

### DIFF
--- a/lib/dm-redis-adapter/adapter.rb
+++ b/lib/dm-redis-adapter/adapter.rb
@@ -155,6 +155,7 @@ module DataMapper
 
         if query.conditions.nil?
           @redis.smembers(key_set_for(query.model)).each do |key|
+            key = key.to_i if key =~ /^\d+$/
             keys << {redis_key_for(query.model) => key}
           end
         else

--- a/spec/dm_redis_validations_spec.rb
+++ b/spec/dm_redis_validations_spec.rb
@@ -118,6 +118,9 @@ describe DataMapper::Adapters::RedisAdapter do
       james = Blackguard.create(:nickname => "James 'cannon-fingers' Doolittle")
       Blackguard.get(petey.id).should_not be_destroyed
       Blackguard.first(:nickname => "James 'cannon-fingers' Doolittle").should_not be_destroyed
+      Blackguard.first.should_not be_destroyed
+      Blackguard.last.should_not be_destroyed
+      Blackguard.all.first.should_not be_destroyed
     end
   end
 


### PR DESCRIPTION
Very similar problem to an older closed issue #12 :

When calling first or last on a model it thinks the object is destroyed? and not saved?.

If you add these tests to the "should not mark the first pirate as destroyed" tests, it will fail:

``` ruby
Blackguard.first.should_not be_destroyed
Blackguard.last.should_not be_destroyed
Blackguard.all.first.should_not be_destroyed
```
