### PR TITLE
Bugfix: non-key, non-index EqualToComparison queries do nothing

### DIFF
--- a/lib/dm-redis-adapter/adapter.rb
+++ b/lib/dm-redis-adapter/adapter.rb
@@ -245,6 +245,8 @@ module DataMapper
               find_indexed_matches(subject, value).each do |k|
                 matched_records << {redis_key_for(query.model) => k, "#{subject.name}" => value}
               end
+            else # worst case here, loop through all members, typecast and match
+              search_all_resources(query, operand, subject, matched_records)
             end
           else # worst case here, loop through all members, typecast and match
             search_all_resources(query, operand, subject, matched_records)


### PR DESCRIPTION
Seems to me that queries like MyModel.all(:neither_primary_nor_index_key_property => "value") never hit the database, and therefore return no results. The switch cases just above my change (ie: for NotOperation and InclusionComparison) seem to account for the possibility... just not EqualToComparisons?

Thanks!
