### PR TITLE
[gemspec] Including Gemfile.

### DIFF
--- a/dm-redis-adapter.gemspec
+++ b/dm-redis-adapter.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |s|
      "spec/dm_redis_validations_spec.rb",
      "spec/self_referential_spec.rb",
      "spec/spec_helper.rb",
-     "spec/textual_keys_spec.rb"
+     "spec/textual_keys_spec.rb",
+     "Gemfile"
   ]
   s.homepage = "http://github.com/whoahbot/dm-redis-adapter"
   s.rdoc_options = ["--charset=UTF-8"]


### PR DESCRIPTION
Various rake commands, as well as `passenger start` will error out at a global scope, noting that dm-redis-adapter does not have a Gemfile.

```
$ rake jobs:work
$ ~/.rvm/gems/ruby-1.9.2-p290/gems/dm-redis-adapter-0.6.3/Gemfile not found
```

This pull request adds Gemfile to the .gemspec.
