### PR TITLE
Using non-serial/integer keys with associations

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -18,7 +18,7 @@ h1. Changelog
 * v0.6.4  Adding the Gemfile so that rake commands work (thanks @kellydunn!)
 * v0.6.3  Fixes a problem with non-index, non-key queries (thanks @thecurator!)
 * v0.6.2  Fixes a problem with 'destroyed' objects (thanks @snovotny!)
-* v0.6.1  Fixes a problem with deleting an object and not having it deleted from an assosciation (thanks @sheur!)
+* v0.6.1  Fixes a problem with deleting an object and not having it deleted from an assosciation (thanks @sheuer!)
 * v0.6.0  Refactor and change to the way that model names are stored in redis
 * v0.5.3  Support for inheritance via sfeu and ujifgc, this version *breaks compatibility* with previous versions of the gem
 * v0.4.0  Support for dm-core v1.1.0
@@ -110,6 +110,6 @@ h1. Badass contributors
 * <a href="http://github.com/arbarlow">Alex Barlow (arbarlow)</a> Fixes for ruby 1.9.2
 * <a href="http://github.com/jof">Jonathan Lassoff (jof)</a> Fixes to support textual keys
 * <a href="http://github.com/sfeu">Sebastian Feuerstack (sfeu)</a> Fixes to support inheritance
-* <a href="http://github.com/sheur">Stephen Heuer (@sheur)</a> Fixes to deleted assosciations
-* <a href="http://github.com/sheur">Steve Novotny (@snovotny)</a> Fixing a bug with 'destroyed' objects
-* <a href="http://github.com/sheur">Andrew Janssen (@thecurator)</a> Fixing a bug with non-index, non-key queries
+* <a href="http://github.com/sheuer">Stephen Heuer (@sheuer)</a> Fixes to deleted assosciations
+* <a href="http://github.com/snovotny">Steve Novotny (@snovotny)</a> Fixing a bug with 'destroyed' objects
+* <a href="http://github.com/thecurator">Andrew Janssen (@thecurator)</a> Fixing a bug with non-index, non-key queries

--- a/lib/dm-redis-adapter/adapter.rb
+++ b/lib/dm-redis-adapter/adapter.rb
@@ -297,7 +297,7 @@ module DataMapper
       #   Array of id's of all members for an indexed field
       # @api private
       def find_indexed_matches(subject, value)
-        @redis.smembers("#{subject.model.storage_name}:#{subject.name}:#{encode(value)}").map {|id| id.to_i}
+        @redis.smembers("#{subject.model.storage_name}:#{subject.name}:#{encode(value)}").map {|id| id =~ /^\d+$/ ? id.to_i : id}
       end
 
       ##

--- a/spec/textual_keys_spec.rb
+++ b/spec/textual_keys_spec.rb
@@ -26,4 +26,29 @@ describe DataMapper::Adapters::RedisAdapter do
       Foo.first.hostname.should == "hostname1"
     end
   end
+  
+  describe "textual keys" do
+    it "should find associated objects using textual key" do
+      class Cart
+        include DataMapper::Resource
+        property :id, String, :key => true, :unique_index => true
+        has n, :items
+      end
+      
+      class Item
+        include DataMapper::Resource
+        property :id, String, :key => true, :unique_index => true
+        property :description, String
+        belongs_to :cart
+      end
+      DataMapper.finalize
+      
+      cart = Cart.create(:id => "6e0fbb69-4e29-4719-a067-a850b5685317")
+      item = cart.items.create(:id => "246ffaed-f060-4a0c-83ef-39008899c0db", :description => "test item")
+      
+      Cart.get("6e0fbb69-4e29-4719-a067-a850b5685317").items.should == [item]
+    end
+  end
+  
+  
 end


### PR DESCRIPTION
Hi Dan,

The project we are working on started using UUIDs instead of just the regular serial ids and I ran into a problem with some of the associations.  It looks like it was to_ i'n the ids so were getting some weird issues like:

```
1.9.3p194 :003 > "246ffaed-f060-4a0c-83ef-39008899c0db".to_i
 => 246 
```

Then we couldn't find the associated objects.

This appears to fix that issue and I've included an updated test.

I also did a quick edit on the README to fix up some usernames and a couple broken links most likely related to a quick copy-pasta.

Thanks,
Steve
