### PR TITLE
Update Rakefile Jeweler to support redis gems > v.2

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ begin
     gemspec.add_dependency "dm-core", ">= 1.2.0"
     gemspec.add_dependency "dm-types", ">= 1.2.0"
     gemspec.add_dependency "hiredis", "~> 0.4.0"
-    gemspec.add_dependency "redis", "~> 2.2"
+    gemspec.add_dependency "redis", ">= 2.2"
     gemspec.files = %w(MIT-LICENSE README.textile Rakefile) + Dir.glob("{lib,spec}/**/*")
     gemspec.has_rdoc = false
     gemspec.extra_rdoc_files = ["MIT-LICENSE"]


### PR DESCRIPTION
There are now "redis" gems of 3.0 and up.

In the Rakefile, there is a "pessimistic" dependency on redis 2.2 (~> 2.2), but this conflicts what's listed in the Gemfile (>= 2.2).

So, when doing a bundle install that is grabbing the latest redis (3.0.2), it fails when I go to actually activate the gem.

As the current test suite seems to pass (MRI 1.9.3, OS X 10.8.2), I figured I'd just update the Jeweler spec to match.
