### PR TITLE
Fix and associated test for composite keys causing type errors

### DIFF
--- a/lib/dm-redis-adapter/adapter.rb
+++ b/lib/dm-redis-adapter/adapter.rb
@@ -150,7 +150,7 @@ module DataMapper
         value =""
         storage_name = query.model.storage_name
         query.conditions.operands.each do |operand|
-          value += operand.value  if operand.subject.key?
+          value += operand.value.to_s if operand.subject.key?
         end
 
         if @redis.sismember(key_set_for(query.model), value)

--- a/spec/composite_keys_spec.rb
+++ b/spec/composite_keys_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe DataMapper::Adapters::RedisAdapter do
+  before(:all) do
+    @adapter = DataMapper.setup(:default, {
+      :adapter  => "redis",
+      :db => 15
+    })
+    @repository = DataMapper.repository(@adapter.name)
+    @redis = Redis.new(:db => 15)
+  end
+
+  after(:each) do
+    @redis.flushdb
+  end
+
+  describe "composite keys" do
+    before(:all) do
+      class CompositeFun
+        include DataMapper::Resource
+
+        property :other_id,   Integer, :key => true, :required => true, :index => true
+        property :id,         Serial, :key => true
+        property :stuff,      String
+        
+        DataMapper.finalize
+      end
+    end
+
+    it "should be able to create and update an item with a composite key" do
+      c = CompositeFun.new(:other_id => 1)
+      c.save
+      c.update(:stuff => "Random String")  # Without the fix in adapter#key_query this throws an exception
+    end
+    
+    it "should save the composite id of the resource in a set" do
+      c = CompositeFun.new(:other_id => 1)
+      c.save
+      @redis.hgetall("composite_funs:#{c.other_id}#{c.id}").should == {"other_id" => "#{c.id}"}
+      @redis.smembers("composite_funs:other_id:id:all").should == ["#{c.other_id}#{c.id}"]
+    end
+  end
+end


### PR DESCRIPTION
Composite keys with a given key, then a serial for uniqueness, were causing the following type error on update (amongst other things):

``` ruby
TypeError: no implicit conversion of Fixnum into String
    from /Users/cknight/.rvm/gems/ruby-2.0.0-p247/gems/dm-redis-adapter-0.8.3/lib/dm-redis-adapter/adapter.rb:153:in `+'
    from /Users/cknight/.rvm/gems/ruby-2.0.0-p247/gems/dm-redis-adapter-0.8.3/lib/dm-redis-adapter/adapter.rb:153:in `block in key_query'
    from /Users/cknight/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/set.rb:232:in `each_key'
    from /Users/cknight/.rvm/rubies/ruby-2.0.0-p247/lib/ruby/2.0.0/set.rb:232:in `each'
    from /Users/cknight/.rvm/gems/ruby-2.0.0-p247/gems/dm-redis-adapter-0.8.3/lib/dm-redis-adapter/adapter.rb:152:in `key_query'
    from /Users/cknight/.rvm/gems/ruby-2.0.0-p247/gems/dm-redis-adapter-0.8.3/lib/dm-redis-adapter/adapter.rb:182:in `records_for'
    from /Users/cknight/.rvm/gems/ruby-2.0.0-p247/gems/dm-redis-adapter-0.8.3/lib/dm-redis-adapter/adapter.rb:77:in `update'
    from /Users/cknight/.rvm/gems/ruby-2.0.0-p247/gems/dm-core-1.2.1/lib/dm-core/repository.rb:180:in `update'
```

A test has been added to cover the fix. Revert the fix to see the test fail.

All original tests still pass, so hopefully things are all still fine...!
