### PR TITLE
explicitly require dm-core

### DIFF
--- a/dm-redis-adapter.gemspec
+++ b/dm-redis-adapter.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = "dm-redis-adapter"
-  s.version = "0.8.4"
+  s.version = "0.9.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Dan Herrera"]

--- a/lib/dm-redis-adapter/adapter.rb
+++ b/lib/dm-redis-adapter/adapter.rb
@@ -1,6 +1,7 @@
 require 'redis/connection/hiredis'
 require 'redis'
 require 'base64'
+require 'dm-core'
 
 module DataMapper
   module Adapters


### PR DESCRIPTION
fix below error
gems/dm-redis-adapter-0.9.0/lib/dm-redis-adapter/adapter.rb:7:in `module:Adapters': uninitialized constant DataMapper::Adapters::AbstractAdapter (NameError)
